### PR TITLE
fixup/server: add small sleep in accept loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bus",
  "env_logger",


### PR DESCRIPTION
Prevents the `accept` loop from consuming too many resources by adding a small sleep. Otherwise, the thread repeatedly makes system calls in a tight loop, and consumes too much CPU time.