### PR TITLE
device_handle: use `Method` aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "ssp"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf013df17d06a80bcee32d425e89cb9c12fd7e123407f4652f4cba03dde0ec4"
+checksum = "2e492166d4e78bcb4380b5799867db1c0763cc2c783854f32a52955987744478"
 dependencies = [
  "aes",
  "bitfield",

--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -561,8 +561,8 @@ impl DeviceHandle {
                 set_jsonrpc_id(jsonrpc_id);
 
                 match method {
-                    ssp::Method::Disable => self.on_disable(stream, &event)?,
-                    ssp::Method::Enable => self.on_enable(stream, &event)?,
+                    ssp::Method::Disable | ssp::Method::Stop => self.on_disable(stream, &event)?,
+                    ssp::Method::Enable | ssp::Method::Accept => self.on_enable(stream, &event)?,
                     ssp::Method::Reject => self.on_reject(stream, &event)?,
                     ssp::Method::Stack => self.on_stack(stream, &event)?,
                     ssp::Method::StackerFull => self.on_stacker_full(stream, &event)?,


### PR DESCRIPTION
Make the `DeviceHandle::on_message` impl more robust by accepting the `Method::Accept` and `Method::Stop` variant aliases to enable and disable the device, respectively.