### PR TITLE
ci: add Github CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,112 @@
+name: ssp-server
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  rustfmt-clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install stable
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - name: Run rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+
+      - name: Run clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --tests
+
+  test:
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        target:
+          - debian: null
+            cross: null
+            rust: null
+        llvm_version: ["5.0", "9.0"]
+        main_tests: [1]
+        release_build: [0, 1]
+        no_default_features: [0, 1]
+        # FIXME: There are no pre-built static libclang libraries, so the
+        # `static` feature is not testable atm.
+        feature_runtime: [0, 1]
+        feature_extra_asserts: [0]
+
+        include:
+          # Test with extra asserts + docs just with latest llvm versions to
+          # prevent explosion
+          - os: ubuntu-latest
+            llvm_version: "9.0"
+            release_build: 0
+            no_default_features: 0
+            feature_extra_asserts: 1
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install multiarch packages
+        if: matrix.target.debian
+        run: |
+          sudo apt-get install binfmt-support qemu-user-static gcc-${{matrix.target.cross}} g++-${{matrix.target.cross}}
+          source /etc/lsb-release
+          sudo tee /etc/apt/sources.list <<EOF >/dev/null
+          deb [arch=${{matrix.target.debian}}] http://ports.ubuntu.com/ubuntu-ports/ $DISTRIB_CODENAME main
+          deb [arch=${{matrix.target.debian}}] http://ports.ubuntu.com/ubuntu-ports/ $DISTRIB_CODENAME-updates main
+          deb [arch=${{matrix.target.debian}}] http://ports.ubuntu.com/ubuntu-ports/ $DISTRIB_CODENAME-backports main
+          deb [arch=${{matrix.target.debian}}] http://ports.ubuntu.com/ubuntu-ports/ $DISTRIB_CODENAME-security main
+          EOF
+          sudo dpkg --add-architecture ${{matrix.target.debian}}
+          sudo apt-get update
+          sudo apt-get install libc6:${{matrix.target.debian}} libstdc++6:${{matrix.target.debian}}
+
+      - name: Install stable
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: ${{matrix.target.rust}}
+      - name: Install libtinfo
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install libtinfo5
+      - name: Run all the tests (debug)
+        env:
+          GITHUB_ACTIONS_OS: ${{matrix.os}}
+          RUST_TARGET: ${{matrix.target.rust}}
+        run: cargo test --all
+      - name: Run all the tests (debug, jsonrpc)
+        env:
+          GITHUB_ACTIONS_OS: ${{matrix.os}}
+          RUST_TARGET: ${{matrix.target.rust}}
+        run: cargo test --all --features jsonrpc
+      - name: Run all the tests (release)
+        env:
+          GITHUB_ACTIONS_OS: ${{matrix.os}}
+          RUST_TARGET: ${{matrix.target.rust}}
+        run: cargo test --all --release
+      - name: Run all the tests (release, jsonrpc)
+        env:
+          GITHUB_ACTIONS_OS: ${{matrix.os}}
+          RUST_TARGET: ${{matrix.target.rust}}
+        run: cargo test --all --release --features jsonrpc


### PR DESCRIPTION
Adds basic runners to test the crate, in both debug/release builds, and different feature combinations.