### PR TITLE
version: bump to v0.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-server"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["SSP Rust Developers"]
 description = "Reference server implementation for the SSP/eSSP serial communication protocol"


### PR DESCRIPTION
Bumps crate version to v0.1.3 to include changes for `DeviceHandle::on_message`.