### PR TITLE
server: separate message handlers, expose private functions to public API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "ssp"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e492166d4e78bcb4380b5799867db1c0763cc2c783854f32a52955987744478"
+checksum = "42741febbf98c8f0be8139e53f822c0210dd3a3dae7ed4c04e2a561484ad4d66"
 dependencies = [
  "aes",
  "bitfield",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-server"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bus",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-server"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bus",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serialport = { version = "4.2", default-features = false }
 signal-hook = "0.3"
 
 [dependencies.ssp]
-version = "0.2"
+version = "0.3"
 features = ["std"]
 
 [dependencies.serde_json]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ categories = ["network-programming"]
 repository = "https://github.com/ssp-rs/ssp-server"
 license = "MIT"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "doc_cfg"]
+
 [dependencies]
 bus = "2.4"
 env_logger = "0.10"
@@ -32,6 +36,7 @@ features = ["std"]
 optional = true
 
 [features]
+default = ["jsonrpc"]
 test-e2e = []
 test-rainbow = []
 jsonrpc = ["serde_json", "smol-jsonrpc", "ssp/jsonrpc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-server"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["SSP Rust Developers"]
 description = "Reference server implementation for the SSP/eSSP serial communication protocol"

--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -578,8 +578,11 @@ impl DeviceHandle {
         Ok(ssp::Method::Disable)
     }
 
+    /// Message handler for [Disable](ssp::Event::DisableEvent) events.
+    /// 
+    /// Exposed to help with creating a custom message handler.
     #[cfg(feature = "jsonrpc")]
-    fn on_disable(&self, stream: &mut UnixStream, _event: &ssp::Event) -> Result<()> {
+    pub fn on_disable(&self, stream: &mut UnixStream, _event: &ssp::Event) -> Result<()> {
         self.disable()?;
 
         let mut res = Response::from(ssp::Event::from(ssp::DisableEvent::new()));
@@ -593,8 +596,11 @@ impl DeviceHandle {
         Ok(())
     }
 
+    /// Message handler for [Enable](ssp::Event::EnableEvent) events.
+    /// 
+    /// Exposed to help with creating a custom message handler.
     #[cfg(feature = "jsonrpc")]
-    fn on_enable(&self, stream: &mut UnixStream, event: &ssp::Event) -> Result<()> {
+    pub fn on_enable(&self, stream: &mut UnixStream, event: &ssp::Event) -> Result<()> {
         // perform full init sequence,
         // only sending EnableCommand does not bring the device online...
         let enable_event = ssp::EnableEvent::try_from(event)?;
@@ -611,8 +617,11 @@ impl DeviceHandle {
         Ok(())
     }
 
+    /// Message handler for [Reject](ssp::Event::RejectEvent) events.
+    /// 
+    /// Exposed to help with creating a custom message handler.
     #[cfg(feature = "jsonrpc")]
-    fn on_reject(&self, stream: &mut UnixStream, _event: &ssp::Event) -> Result<()> {
+    pub fn on_reject(&self, stream: &mut UnixStream, _event: &ssp::Event) -> Result<()> {
         self.reject()?;
 
         let mut res = Response::from(ssp::Event::from(ssp::RejectEvent::new()));
@@ -626,8 +635,11 @@ impl DeviceHandle {
         Ok(())
     }
 
+    /// Message handler for [Stack](ssp::Event::StackEvent) events.
+    /// 
+    /// Exposed to help with creating a custom message handler.
     #[cfg(feature = "jsonrpc")]
-    fn on_stack(&self, stream: &mut UnixStream, _event: &ssp::Event) -> Result<()> {
+    pub fn on_stack(&self, stream: &mut UnixStream, _event: &ssp::Event) -> Result<()> {
         let value = self.stack()?;
 
         let mut res = Response::from(ssp::Event::from(ssp::StackEvent::from(value)));
@@ -641,19 +653,34 @@ impl DeviceHandle {
         Ok(())
     }
 
+    /// Message handler for [StackerFull](ssp::Event::StackerFullEvent) events.
+    /// 
+    /// Exposed to help with creating a custom message handler.
     #[cfg(feature = "jsonrpc")]
-    fn on_stacker_full(&self, _stream: &mut UnixStream, _event: &ssp::Event) -> Result<()> {
+    pub fn on_stacker_full(&self, _stream: &mut UnixStream, _event: &ssp::Event) -> Result<()> {
         Err(ssp::Error::JsonRpc(
             "StackerFull handler unimplemented".into(),
         ))
     }
 
+    /// Message handler for [Status](ssp::Event::StatusEvent) events.
+    /// 
+    /// Exposed to help with creating a custom message handler.
     #[cfg(feature = "jsonrpc")]
-    fn on_status(&self, stream: &mut UnixStream, _event: &ssp::Event) -> Result<()> {
+    pub fn on_status(&self, stream: &mut UnixStream, _event: &ssp::Event) -> Result<()> {
         let data = self.unit_data()?;
-        let status = ssp::DeviceStatus::from(data);
 
-        let mut res = Response::from(ssp::Event::from(ssp::StatusEvent::new(status)));
+        let cashbox_available = cashbox_available();
+        let status = ssp::DeviceStatus::from(data)
+            .with_cashbox_attached(cashbox_available);
+
+        let event = if cashbox_available {
+            ssp::StatusEvent::new(status)
+        } else {
+            ssp::StatusEvent::new(status.with_response_status(ssp::ResponseStatus::CashboxRemoved))
+        };
+
+        let mut res = Response::from(ssp::Event::from(event));
         res.set_id(jsonrpc_id());
 
         let mut res_str = serde_json::to_string(&res)?;
@@ -664,6 +691,14 @@ impl DeviceHandle {
         Ok(())
     }
 
+    /// Message handler for [Status](ssp::Event::StatusEvent) events.
+    /// 
+    /// Exposed to help with creating a custom message handler.
+    ///
+    /// **WARNING**: currently, the server requires a restart after a device reset. This seems to
+    /// be implementation specific, since the documentation describes a procedure for re-enabling
+    /// the device without a server restart. However, following the documentation procedure results
+    /// in an inoperable server... TBD.
     // FIXME: the server needs to restart after the device is reset, then everything works as
     // normal.
     //
@@ -675,7 +710,7 @@ impl DeviceHandle {
     //
     // Regardless, neither value works, and the only thing that works is a server reset...
     #[cfg(feature = "jsonrpc")]
-    fn on_reset(&self, stream: &mut UnixStream, _event: &ssp::Event) -> Result<()> {
+    pub fn on_reset(&self, stream: &mut UnixStream, _event: &ssp::Event) -> Result<()> {
         self.reset()?;
 
         let now = time::Instant::now();
@@ -730,7 +765,7 @@ impl DeviceHandle {
         Err(ssp::Error::JsonRpc("failed to reset device".into()))
     }
 
-    /// Get the serial port used for communication with the acceptor device
+    /// Acquires a lock on the serial port used for communication with the acceptor device.
     pub fn serial_port(&self) -> Result<MutexGuard<'_, TTYPort>> {
         Self::lock_serial_port(&self.serial_port)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
+
 pub mod device_handle;
 #[macro_use]
 mod macros;

--- a/src/server.rs
+++ b/src/server.rs
@@ -74,6 +74,7 @@ impl Server {
     /// Creates a new [Server] that interactively handles device events via
     /// a client connects over Unix domain sockets.
     #[cfg(feature = "jsonrpc")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "jsonrpc")))]
     pub fn new_uds(
         serial_path: &str,
         socket_path: &str,
@@ -271,7 +272,10 @@ impl Server {
     fn send(stream: &mut UnixStream, msg: &Event) -> Result<()> {
         log::debug!("Sending push event: {msg}");
 
-        let push_req = smol_jsonrpc::Request::new().with_params(msg);
+        let push_req = smol_jsonrpc::Request::new()
+            .with_method(msg.method().to_str())
+            .with_params(msg);
+
         let mut json_str = serde_json::to_string(&push_req)?;
         json_str += "\n";
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -35,7 +35,7 @@ fn set_stop_serving_client(s: bool) {
 ///
 /// Optionally, can be used interactively with a client connection.
 pub struct Server {
-    handle: Arc<Mutex<DeviceHandle>>,
+    pub handle: Arc<Mutex<DeviceHandle>>,
     #[cfg(feature = "jsonrpc")]
     socket_path: Option<String>,
     #[cfg(feature = "jsonrpc")]
@@ -113,7 +113,10 @@ impl Server {
         Self::lock_handle(&self.handle)
     }
 
-    fn lock_handle(handle: &Arc<Mutex<DeviceHandle>>) -> Result<MutexGuard<'_, DeviceHandle>> {
+    /// Aquires a lock on the [DeviceHandle].
+    ///
+    /// Returns an `Err(_)` if the timeout expires before acquiring the lock.
+    pub fn lock_handle(handle: &Arc<Mutex<DeviceHandle>>) -> Result<MutexGuard<'_, DeviceHandle>> {
         let now = time::Instant::now();
 
         while now.elapsed().as_millis() < HANDLE_TIMEOUT_MS {


### PR DESCRIPTION
Adds the individual message handler functions to the public API, and adds the `Server::lock_handle` function to the public API.

These changes should allow for more modular re-use of the crate for external users.

Bumps the `ssp` dependency version to bring in the necessary updates to `DeviceStatus` and message parsing.