### PR TITLE
version: bump to v0.1.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,23 +43,7 @@ jobs:
           - debian: null
             cross: null
             rust: null
-        llvm_version: ["5.0", "9.0"]
-        main_tests: [1]
-        release_build: [0, 1]
-        no_default_features: [0, 1]
-        # FIXME: There are no pre-built static libclang libraries, so the
-        # `static` feature is not testable atm.
-        feature_runtime: [0, 1]
-        feature_extra_asserts: [0]
-
-        include:
-          # Test with extra asserts + docs just with latest llvm versions to
-          # prevent explosion
-          - os: ubuntu-latest
-            llvm_version: "9.0"
-            release_build: 0
-            no_default_features: 0
-            feature_extra_asserts: 1
+        llvm_version: ["9.0"]
 
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-server"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["SSP Rust Developers"]
 description = "Reference server implementation for the SSP/eSSP serial communication protocol"


### PR DESCRIPTION
Bumps release version to `0.1.5` to include fixes for server resource consumption, and soft-resetting a device without restarting the server.

Reduces the overall number of CI runners by simplifying the OS matrix. The original YAML file was copied from a project that needed a more diverse set of environments to test against, our use-case is much simpler.