### PR TITLE
fixup/device_handle: resolve encryption key deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-server"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bus",
  "env_logger",


### PR DESCRIPTION
Fixes deadlock on acquiring a lock on the encryption key mutex when multiple `*_inner` functions are called outside the background polling thread. Instead of locking/unlocking the mutex, the mutex is locked once at the start of the function, e.g. `DeviceHandle::enable_device`, passed to all callees that require it, and unlocked when the guard goes out of scope.