### PR TITLE
fixup/server: add more reset fixes

### DIFF
--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -761,12 +761,6 @@ impl DeviceHandle {
 
                     let poll_res = self.poll_inner(&mut serial_port, None)?;
                     if poll_res.response_status().is_ok() {
-                        let res = Response::from(ssp::Event::from(ssp::ResetEvent::new()))
-                            .with_id(jsonrpc_id());
-
-                        let mut res_str = serde_json::to_string(&res)?;
-                        res_str += "\n";
-
                         log::debug!("Successfully reset device: {res_str}");
 
                         return Ok(());

--- a/src/server.rs
+++ b/src/server.rs
@@ -91,7 +91,10 @@ impl Server {
         while let Err(err) = handle.enable_device(protocol_version) {
             log::error!("error enabling device: {err}, resetting");
 
-            handle.full_reset()?;
+            if let Err(err) = handle.full_reset() {
+                log::error!("error resetting device: {err}");
+            }
+
             reset_count += 1;
 
             if reset_count >= MAX_RESETS {


### PR DESCRIPTION
Logs errors on reset failure, but does not bubble up the error until the max number of resets.