### PR TITLE
version: bump `ssp` to v0.4.0, and `ssp-server` version to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,8 +690,9 @@ dependencies = [
 
 [[package]]
 name = "ssp"
-version = "0.3.0"
-source = "git+https://github.com/ssp-rs/ssp#359ff16990601a9e2812d4a1f912de33c2e7f961"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18dd4ee81dfcd2d25775bbf133a5485da0d95ed095ebdce6a30f94ec0cf4051"
 dependencies = [
  "aes",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-server"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2021"
 authors = ["SSP Rust Developers"]
 description = "Reference server implementation for the SSP/eSSP serial communication protocol"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,8 @@ serialport = { version = "4.2", default-features = false }
 signal-hook = "0.3"
 
 [dependencies.ssp]
-version = "0.3"
+version = "0.4"
 features = ["std"]
-git = "https://github.com/ssp-rs/ssp"
 
 [dependencies.serde_json]
 version = "1.0"


### PR DESCRIPTION
Bumps minor version to include changes to encryption.

Moves `ssp` from git dependency to the latest published version.