### PR TITLE
version: bump to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-server"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bus",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-server"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["SSP Rust Developers"]
 description = "Reference server implementation for the SSP/eSSP serial communication protocol"

--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -1633,8 +1633,7 @@ impl DeviceHandle {
         message: &mut ssp::PayoutByDenominationCommand,
         key: Option<&ssp::AesKey>,
     ) -> Result<()> {
-        let mut test_cmd = message
-            .with_payout_option(ssp::PayoutOption::TestPayoutAmount);
+        let mut test_cmd = message.with_payout_option(ssp::PayoutOption::TestPayoutAmount);
         let test_res = Self::poll_message(serial_port, &mut test_cmd, key)?;
 
         log::trace!("Test payout response: {test_res:?}");


### PR DESCRIPTION
Bumps the minor version for backwards-incompatible updates to encryption mode.