### PR TITLE
version: bump to 0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-server"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["SSP Rust Developers"]
 description = "Reference server implementation for the SSP/eSSP serial communication protocol"


### PR DESCRIPTION
Bumps the patch release version to `v0.3.2` to include mock device feature.