### PR TITLE
version: bump to 0.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-server"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["SSP Rust Developers"]
 description = "Reference server implementation for the SSP/eSSP serial communication protocol"


### PR DESCRIPTION
Bumps the patch release to `v0.3.3` to include automatic reset on `UnsafeJam` feature.