### PR TITLE
device_handle: use crossbeam for cross-thread communication primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "ssp-server"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "bus",
  "crossbeam",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,23 +143,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
+name = "crossbeam"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
 dependencies = [
- "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crypto-common"
@@ -734,9 +771,10 @@ dependencies = [
 
 [[package]]
 name = "ssp-server"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bus",
+ "crossbeam",
  "env_logger",
  "log",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssp-server"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 authors = ["SSP Rust Developers"]
 description = "Reference server implementation for the SSP/eSSP serial communication protocol"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ version = "0.2"
 features = ["std"]
 optional = true
 
+[dependencies.crossbeam]
+version = "0.8"
+
 [features]
 default = ["jsonrpc"]
 test-crypto = []

--- a/src/device_handle/inner.rs
+++ b/src/device_handle/inner.rs
@@ -1,7 +1,6 @@
 //! Holds private implementations of [DeviceHandle] functionality.
 
-use std::sync::mpsc;
-
+use crossbeam::channel;
 use ssp::MessageOps;
 
 use crate::continue_on_err;
@@ -14,7 +13,7 @@ use super::{
 impl DeviceHandle {
     pub(crate) fn parse_events(
         poll_res: &ssp::PollResponse,
-        tx: &mpsc::Sender<ssp::Event>,
+        tx: &channel::Sender<ssp::Event>,
     ) -> ssp::Result<()> {
         let data = poll_res.data();
         let data_len = data.len();


### PR DESCRIPTION
Switches to `crossbeam` from `std::mpsc` for cross-thread communication primitives.

Bumps the minor release version to `v0.4.0` for the switch to `crossbeam`.